### PR TITLE
merge full context, avoid injecting keys, allow map[string]any as con…

### DIFF
--- a/context.go
+++ b/context.go
@@ -4,25 +4,16 @@ import (
 	"dario.cat/mergo"
 	"github.com/crossplane/function-sdk-go/errors"
 	fnv1beta1 "github.com/crossplane/function-sdk-go/proto/v1beta1"
-	"github.com/crossplane/function-sdk-go/request"
-	"github.com/crossplane/function-sdk-go/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// MergeContextKey merges existing Context at a key with context data val
-func (f *Function) MergeContextKey(key string, val map[string]interface{}, req *fnv1beta1.RunFunctionRequest) (*unstructured.Unstructured, error) {
-	// Check if key is already defined in the context and merge fields
-	var mergedContext *unstructured.Unstructured
-	if v, ok := request.GetContextKey(req, key); ok {
-		mergedContext = &unstructured.Unstructured{}
-		if err := resource.AsObject(v.GetStructValue(), mergedContext); err != nil {
-			return mergedContext, errors.Wrapf(err, "cannot get Composition environment from %T context key %q", req, key)
-		}
-		f.log.Debug("Loaded Existing Function Context", "context-key", key)
-		if err := mergo.Merge(&mergedContext.Object, val, mergo.WithOverride); err != nil {
-			return mergedContext, errors.Wrapf(err, "cannot merge data %T at context key %q", req, key)
-		}
+// MergeContext merges existing Context with new values provided
+func (f *Function) MergeContext(req *fnv1beta1.RunFunctionRequest, val map[string]interface{}) (map[string]interface{}, error) {
+	mergedContext := req.GetContext().AsMap()
+	if len(val) == 0 {
 		return mergedContext, nil
 	}
-	return &unstructured.Unstructured{Object: val}, nil
+	if err := mergo.Merge(&mergedContext, val, mergo.WithOverride); err != nil {
+		return mergedContext, errors.Wrapf(err, "cannot merge data %T", req)
+	}
+	return mergedContext, nil
 }

--- a/context_test.go
+++ b/context_test.go
@@ -3,51 +3,21 @@ package main
 import (
 	"testing"
 
-	"github.com/crossplane-contrib/function-go-templating/input/v1beta1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	fnv1beta1 "github.com/crossplane/function-sdk-go/proto/v1beta1"
 	"github.com/crossplane/function-sdk-go/resource"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const (
-	environmentKey                  = "apiextensions.crossplane.io/environment"
-	contextFromEnvironment          = `{"apiextensions.crossplane.io/environment":{"complex":{"a":"b","c":{"d":"e","f":"1","overWrite": "fromContext"}}}}`
-	malformedContextFromEnvironment = `{"apiextensions.crossplane.io/environment":{"badkey":,"complex":{"a":"b","c":{"d":"e","f":"1","overWrite": "fromContext"}}}}`
-	contextNew                      = `apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
-	kind: Context
-	data:
-	  newKey:
-		hello: world
-      overWrite: fromFunction`
-
-	contextWithMergeKey = `apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
-kind: Context
-data:
-  "apiextensions.crossplane.io/environment":
-	 update: environment
-	 nestedEnvUpdate:
-	   hello: world
-	complex:
-	  c:
-	    overWrite: fromFunction
-  "other-context-key":
-	complex: {{ index .context "apiextensions.crossplane.io/environment" "complex" | toYaml | nindent 6 }}
-  newkey:
-	hello: world`
-)
-
-func TestMergeContextKeys(t *testing.T) {
+func TestMergeContext(t *testing.T) {
 	type args struct {
-		key string
 		val map[string]interface{}
 		req *fnv1beta1.RunFunctionRequest
 	}
 	type want struct {
-		us  *unstructured.Unstructured
+		us  map[string]any
 		err error
 	}
 
@@ -59,77 +29,36 @@ func TestMergeContextKeys(t *testing.T) {
 		"NoContextAtKey": {
 			reason: "When there is no existing context data at the key to merge, return the value",
 			args: args{
-				key: "newkey",
 				req: &fnv1beta1.RunFunctionRequest{
-					Input: resource.MustStructObject(
-						&v1beta1.GoTemplate{
-							Source: v1beta1.InlineSource,
-							Inline: &v1beta1.TemplateSourceInline{Template: contextNew},
-						}),
-					Observed: &fnv1beta1.State{
-						Composite: &fnv1beta1.Resource{
-							Resource: resource.MustStructJSON(xr),
-						},
-						Resources: map[string]*fnv1beta1.Resource{
-							"cool-cd": {
-								Resource: resource.MustStructJSON(cd),
-							},
-						},
-					},
-					Desired: &fnv1beta1.State{
-						Composite: &fnv1beta1.Resource{
-							Resource: resource.MustStructJSON(xr),
-						},
-					},
+					Context: nil,
 				},
 				val: map[string]interface{}{"hello": "world"},
 			},
 			want: want{
-				us: &unstructured.Unstructured{
-					Object: map[string]interface{}{"hello": "world"},
-				},
+				us:  map[string]interface{}{"hello": "world"},
 				err: nil,
 			},
 		},
 		"SuccessfulMerge": {
 			reason: "Confirm that keys are merged with source overwriting destination",
 			args: args{
-				key: environmentKey,
 				req: &fnv1beta1.RunFunctionRequest{
-					Context: resource.MustStructJSON(contextFromEnvironment),
-					Input: resource.MustStructObject(
-						&v1beta1.GoTemplate{
-							Source: v1beta1.InlineSource,
-							Inline: &v1beta1.TemplateSourceInline{Template: contextWithMergeKey},
-						}),
-					Observed: &fnv1beta1.State{
-						Composite: &fnv1beta1.Resource{
-							Resource: resource.MustStructJSON(xr),
-						},
-						Resources: map[string]*fnv1beta1.Resource{
-							"cool-cd": {
-								Resource: resource.MustStructJSON(cd),
-							},
-						},
-					},
-					Desired: &fnv1beta1.State{
-						Composite: &fnv1beta1.Resource{
-							Resource: resource.MustStructJSON(xr),
-						},
-					},
+					Context: resource.MustStructJSON(`{"apiextensions.crossplane.io/environment":{"complex":{"a":"b","c":{"d":"e","f":"1","overWrite": "fromContext"}}}}`),
 				},
 				val: map[string]interface{}{
 					"newKey": "newValue",
-					"complex": map[string]any{
-						"c": map[string]any{
-							"overWrite": "fromFunction",
+					"apiextensions.crossplane.io/environment": map[string]any{
+						"complex": map[string]any{
+							"c": map[string]any{
+								"overWrite": "fromFunction",
+							},
 						},
 					},
 				},
 			},
 			want: want{
-				us: &unstructured.Unstructured{
-					Object: map[string]interface{}{
+				us: map[string]interface{}{
+					"apiextensions.crossplane.io/environment": map[string]any{
 						"complex": map[string]any{
 							"a": "b",
 							"c": map[string]any{
@@ -138,8 +67,8 @@ func TestMergeContextKeys(t *testing.T) {
 								"overWrite": "fromFunction",
 							},
 						},
-						"newKey": "newValue"},
-				},
+					},
+					"newKey": "newValue"},
 				err: nil,
 			},
 		},
@@ -149,10 +78,10 @@ func TestMergeContextKeys(t *testing.T) {
 			f := &Function{
 				log: logging.NewNopLogger(),
 			}
-			rsp, err := f.MergeContextKey(tc.args.key, tc.args.val, tc.args.req)
+			rsp, err := f.MergeContext(tc.args.req, tc.args.val)
 
 			if diff := cmp.Diff(tc.want.us, rsp, protocmp.Transform()); diff != "" {
-				t.Errorf("%s\nf.MergeContextKey(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
+				t.Errorf("%s\nf.MergeContext(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
 			}
 
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {

--- a/example/context/composition.yaml
+++ b/example/context/composition.yaml
@@ -34,6 +34,8 @@ spec:
           data:
             # update existing EnvironmentConfig by using the "apiextensions.crossplane.io/environment" key
             "apiextensions.crossplane.io/environment":
+               kind: Environment,
+               apiVersion: internal.crossplane.io/v1alpha1,
                update: environment
                nestedEnvUpdate:
                  hello: world

--- a/fn_test.go
+++ b/fn_test.go
@@ -31,7 +31,7 @@ var (
 
 	metaResourceInvalid        = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"InvalidMeta"}`
 	metaResourceConDet         = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"CompositeConnectionDetails","data":{"key":"dmFsdWU="}}` // encoded string "value"
-	metaResourceContextInvalid = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"Context","data":{"new": "value"}}`
+	metaResourceContextInvalid = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"Context","data": 1 }`
 	metaResourceContext        = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"Context","data":{"apiextensions.crossplane.io/environment":{ "new":"value"}}}`
 
 	xr                    = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2}}`
@@ -627,7 +627,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
-							Message:  "error parsing Context data from *v1beta1.RunFunctionRequest context key \"new\". Must be a map.",
+							Message:  "cannot get Contexts from input: cannot unmarshal value from JSON: json: cannot unmarshal number into Go value of type map[string]interface {}",
 						},
 					},
 				},
@@ -665,8 +665,6 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(
 						`{
 							"apiextensions.crossplane.io/environment": {
-							  "kind": "Environment",
-							  "apiVersion": "internal.crossplane.io/v1alpha1",
 							  "new": "value"
 							}
 						  }`,


### PR DESCRIPTION
…text

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

The injection of `apiVersion` and `kind` in context keys is actually a thing we needed to use the environment as a kubernetes object in `function-patch-and-transform`, as that was how crossplane sends it over and expected it before we moved it out. We should actually inject it if needed on `function-patch-and-transform` side if needed, but for sure I'd rather avoid propagating this awkward thing to other functions, so I dropped that, as you can see from the example people can add it to their `Context` meta resource at `apiextensions.crossplane.io/environment` and everything should work fine.

Context can actually be of the form `map[string]any`, no need to enforce it to be `map[string]map[string]any, so I modified the expected meta resource to allow that.

I also rewrote the merge logic to just merge the whole context instead of key by key, which indeed allows the above, we still have to iterate keys when setting keys in the response, but it's a missing function on the sdk side to be able to set the whole context, we should add that.

Fixes # 

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
